### PR TITLE
Update package.json to work with Alexa App Server

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "josh skeen",
   "license": "ISC",
   "dependencies": {
-    "alexa-app": "^2.3.2",
+    "alexa-app": "^3.1.0",
     "dynasty": "^0.2.4",
     "lodash": "^4.3.0"
   }


### PR DESCRIPTION
Some of the old Tutorials have Alexa-App locked in around 2.3/2.4, but the Alexa-App-Server runs Alexa on ~3.1 which causes errors when you try to spin up the server.